### PR TITLE
chore!: removed ramda pipe export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,3 @@ export * from './runner'
 export * from './query'
 export * from './types'
 export * from './manager'
-
-export { pipe } from 'ramda'


### PR DESCRIPTION
BREAKING CHANGE: we are no longer exposing pipe from our package. Users should install `ramda` and `rxjs` in their projects for best devx